### PR TITLE
Add check for `UNAuthorizationOptionProvidesAppNotificationSettings`

### DIFF
--- a/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
@@ -225,7 +225,9 @@ RCT_EXPORT_METHOD(requestPermission
     }
 
     if ([permissions[@"providesAppNotificationSettings"] isEqual:@(YES)]) {
-      options |= UNAuthorizationOptionProvidesAppNotificationSettings;
+      if (@available(iOS 12.0, *)) {
+        options |= UNAuthorizationOptionProvidesAppNotificationSettings;
+      }
     }
 
     UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];


### PR DESCRIPTION
Add check for `UNAuthorizationOptionProvidesAppNotificationSettings` in iOS 12 and newer

### Description

There are some warnings while using UNAuthorizationOptionProvidesAppNotificationSettings without version check.

### Related issues

No related issues.

### Release Summary

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
